### PR TITLE
Fix issue with "B" button on external gamepads

### DIFF
--- a/DeviceParts/src/org/omnirom/device/KeyHandler.java
+++ b/DeviceParts/src/org/omnirom/device/KeyHandler.java
@@ -104,7 +104,7 @@ public class KeyHandler implements DeviceKeyHandler {
     private static final String DOZE_INTENT = "com.android.systemui.doze.pulse";
     private static final int HANDWAVE_MAX_DELTA_MS = 1000;
     private static final int POCKET_MIN_DELTA_MS = 5000;
-    private static final int FP_GESTURE_LONG_PRESS = 305;
+    private static final int FP_GESTURE_LONG_PRESS = 905;
 
     private static final boolean sIsOnePlus6 = android.os.Build.MODEL.equals("ONEPLUS A6003");
 


### PR DESCRIPTION
The code 305 is used for the "B" button on Bluetooth (and I think also USB) gamepads. This change resolves that conflict.